### PR TITLE
Python, Homebrew, GCC, SpotMenu and CI updates

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,5 @@
 if OS.linux?
   tap "linuxbrew/xorg"
-  brew "gcc"
   brew "adoptopenjdk@11"
 end
 
@@ -16,13 +15,13 @@ brew "cfn-lint"
 brew "csshx"
 brew "curl"
 brew "direnv"
+brew "gcc"
 brew "git"
 brew "git-archive-all"
 brew "git-crypt"
 brew "git-flow-avh"
 brew "git-lfs"
 brew "gnu-sed"
-brew "python"
 brew "shellcheck"
 brew "tree"
 brew "watch"
@@ -36,7 +35,6 @@ if OS.mac?
   brew "ffmpeg"
   brew "gnupg"
   brew "vim"
-  brew "youtube-dl"
 
   cask "1password"
   cask "adoptopenjdk11"
@@ -57,6 +55,7 @@ if OS.mac?
   cask "nordvpn"
   cask "sizeup"
   cask "spotify"
+  cask "spotmenu"
   cask "vlc"
   cask "whatsapp"
   cask "zoomus"

--- a/dotfiles/.aliases
+++ b/dotfiles/.aliases
@@ -62,10 +62,13 @@ alias sudo='sudo '
 # Get week number
 alias week='date +%V'
 
+# Get timestamp
+alias timestamp='date +%Y%m%d%H%M%S'
+
 # Stopwatch
 alias timer='echo "Timer started. Stop with Ctrl-D." && date && time cat && date'
 
-# Get Software Updates, update installed Homebrew formulae etc
+# Get Software Updates, update installed Homebrew packages etc
 alias update='~/.dotfiles/scripts/update.sh'
 
 # Show active network interfaces

--- a/scripts/brew.sh
+++ b/scripts/brew.sh
@@ -30,7 +30,29 @@ install() {
     brew cleanup
     brew doctor
   else
-    echo "[ci-skip] Check your Homebrew system for potential problems ..."
+    echo "[skip ci] Check your Homebrew system for potential problems ..."
+  fi
+
+  # Uninstall unwanted pre-installed packages on CI build agents
+  # See links below for installed software:
+  # https://github.com/microsoft/azure-pipelines-image-generation/tree/master/images
+  # https://github.com/actions/virtual-environments/tree/main/images
+  if [[ "${CI_ENABLED}" ]]; then
+    echo "[INFO] Uninstall unwanted pre-installed packages on CI build agents ..."
+    BREW_PACKAGES=('aws-sam-cli' 'session-manager-plugin')
+    for package in "${BREW_PACKAGES[@]}"; do
+      brew uninstall "$package" --force
+    done
+    FILES="/usr/local/bin/aws
+    /usr/local/aws-cli/aws
+    /usr/local/bin/aws_completer
+    /usr/local/aws-cli/aws_completer"
+    for file in $FILES; do
+      if [ -f "$file" ]; then
+        echo "[INFO] Removing $file ..."
+        sudo rm "$file"
+      fi
+    done
   fi
 
   # Run Homebrew through the Brewfile
@@ -47,14 +69,14 @@ uninstall() {
     if test "$(command -v brew)"; then
       if test "$(uname -s)" = "Darwin"; then
         echo "[INFO] Uninstall packages installed using Brew cask ..."
-        brew cask uninstall --force "$(brew cask list)" && brew cask cleanup
+        brew cask uninstall --force "$(brew list --cask)" && brew cask cleanup
       fi
       echo "[INFO] Uninstall packages installed using Brew ..."
       brew remove --force "$(brew list)" && brew cleanup
       /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"
     fi
   else
-    log "[ci-skip] Uninstall Homebrew"
+    log "[skip ci] Uninstall Homebrew"
   fi
 }
 

--- a/scripts/ssh.sh
+++ b/scripts/ssh.sh
@@ -35,5 +35,5 @@ if [[ -z "${CI_ENABLED}" ]]; then
     ssh-keygen -t rsa -C "${email}"
   fi
 else
-  log "[ci-skip] Creating ~/.ssh"
+  log "[skip ci] Creating ~/.ssh"
 fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -30,21 +30,25 @@ fi
 
 # Update Brew
 if test "$(command -v brew)"; then
-  # Check your Homebrew system for potential problems
+  # Checking your Homebrew system for potential problems
   if [[ -z "${CI_ENABLED}" ]]; then
-    echo "[INFO] Check your Homebrew system for potential problems ..."
+    log "Checking your Homebrew system for potential problems"
     brew cleanup
     brew doctor
   else
-    echo "[ci-skip] Check your Homebrew system for potential problems ..."
+    echo "[skip ci] Checking your Homebrew system for potential problems"
   fi
 
-  # Ensure we’re using the latest version of Homebrew.
-  log "Updating Homebrew"
-  brew update
+  # Ensure we're using the latest version of Homebrew.
+  if [[ -z "${CI_ENABLED}" ]]; then
+    log "Updating Homebrew"
+    brew update
+  else
+    echo "[skip ci] Updating Homebrew"
+  fi
 
-  # Upgrade any already-installed formulae.
-  log "Updating installed Homebrew formulae"
+  # Upgrade any already-installed packages.
+  log "Updating installed Homebrew packages"
   brew upgrade
   if test "$(uname -s)" = "Darwin"; then
     brew upgrade --cask


### PR DESCRIPTION
* Remove python (will be installed as a dependency)
* Install gcc on macOS and Linux
* Add `timestamp` alias
* Uninstall unwanted pre-installed packages on CI build agents which causes CI build to fail
  See links below for installed software:
    https://github.com/microsoft/azure-pipelines-image-generation/tree/master/images
    https://github.com/actions/virtual-environments/tree/main/images
* Do not run `brew update` on CI builds
* `brew cask list` is deprecated. Use `brew list --cask` instead
* Rename "[ci-skip]" output to "[skip ci]"
* Add SpotMenu - Spotify and iTunes in your menu bar
* Remove youtube-dl
  This has been removed from GitHub following a takedown notice from the RIAA.
  See https://github.com/github/dmca/blob/master/2020/10/2020-10-23-RIAA.md