### PR TITLE
Adjust toolbar title rollover delay

### DIFF
--- a/scripts/macos.sh
+++ b/scripts/macos.sh
@@ -60,6 +60,9 @@ defaults write NSGlobalDomain AppleShowScrollBars -string "Always"
 # Disable the over-the-top focus ring animation
 defaults write NSGlobalDomain NSUseAnimatedFocusRing -bool false
 
+# Adjust toolbar title rollover delay
+defaults write NSGlobalDomain NSToolbarTitleViewRolloverDelay -float 0
+
 # Disable smooth scrolling
 # (Uncomment if you’re on an older Mac that messes up the animation)
 #defaults write NSGlobalDomain NSScrollAnimationEnabled -bool false


### PR DESCRIPTION
Remove the delay when hovering the toolbar title in macOS Big Sur