### PR TITLE
Disable sound effects on boot

### DIFF
--- a/scripts/macos.sh
+++ b/scripts/macos.sh
@@ -42,7 +42,7 @@ log "General UI/UX"
 defaults write -globalDomain AppleInterfaceStyle -string Dark
 
 # Disable the sound effects on boot
-sudo nvram SystemAudioVolume=" "
+sudo nvram StartupMute=%01
 
 # Disable transparency in the menu bar and elsewhere on Yosemite
 #defaults write com.apple.universalaccess reduceTransparency -bool true
@@ -386,6 +386,7 @@ defaults write com.apple.dock mru-spaces -bool false
 
 # Remove the auto-hiding Dock delay
 defaults write com.apple.dock autohide-delay -float 0
+
 # Remove the animation when hiding/showing the Dock
 defaults write com.apple.dock autohide-time-modifier -float 0
 


### PR DESCRIPTION
With Big Sur, `SystemAudioVolume` no longer works.
Use `StartupMute` instead.