### PR TITLE
Update .editorconfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
   # dotfiles - install
   ####################
   dotfiles-install:
-    needs: [shellcheck]
+    needs: [ shellcheck ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-latest]
+        os: [ macOS-latest, ubuntu-latest ]
     env:
       CI: 1
       # Uncomment to help debug Homebrew issues
@@ -128,11 +128,11 @@ jobs:
   # dotfiles - uninstall
   ######################
   dotfiles-uninstall:
-    needs: [dotfiles-install]
+    needs: [ dotfiles-install ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-latest]
+        os: [ macOS-latest, ubuntu-latest ]
     env:
       CI: 1
     steps:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 Your dotfiles are how you personalize your system. These are mine.
 
-**Warning:** If you want to give these dotfiles a try, you should first fork this repository, review the code, and remove things you don’t want or need. Don’t blindly use my settings unless you know what that entails. Use at your own risk!
+**Warning:** If you want to give these dotfiles a try, you should first fork this repository, review the code, and
+remove things you don’t want or need. Don’t blindly use my settings unless you know what that entails. Use at your own
+risk!
 
 ## Prerequisites
 
@@ -27,8 +29,8 @@ cd ~/.dotfiles
 ./bootstrap.sh --install
 ```
 
-This will symlink the files in `~/.dotfiles/dotfiles` to your home directory.
-Everything is configured and tweaked within `~/.dotfiles`.
+This will symlink the files in `~/.dotfiles/dotfiles` to your home directory. Everything is configured and tweaked
+within `~/.dotfiles`.
 
 ### Specify the `$PATH`
 
@@ -42,9 +44,11 @@ export PATH="/usr/local/bin:$PATH"
 
 ### Add custom commands
 
-If `~/.extra` exists, it will be sourced along with the other files. You can use this to add a few custom commands without the need to fork this entire repository, or to add commands you don’t want to commit to a public repository.
+If `~/.extra` exists, it will be sourced along with the other files. You can use this to add a few custom commands
+without the need to fork this entire repository, or to add commands you don’t want to commit to a public repository.
 
-My `~/.extra` looks something like this (and I use `githome` and `gitwork` aliases to switch between home and work email addresses):
+My `~/.extra` looks something like this (and I use `githome` and `gitwork` aliases to switch between home and work email
+addresses):
 
 ```bash
 # Git credentials
@@ -96,7 +100,8 @@ $ git remote -v
 > origin  git@github.com:USERNAME/REPOSITORY.git (push)
 ```
 
-:octocat: [Reference](https://docs.github.com/en/github/using-git/changing-a-remotes-url#switching-remote-urls-from-https-to-ssh)
+:
+octocat: [Reference](https://docs.github.com/en/github/using-git/changing-a-remotes-url#switching-remote-urls-from-https-to-ssh)
 </details>
 
 ## Uninstall
@@ -113,7 +118,8 @@ rm -rf ~/.dotfiles
 
 ## Credits
 
-This project uses open source components. You can find the source code of their open source projects along with license information below. We acknowledge and are grateful to these developers for their contributions to open source.
+This project uses open source components. You can find the source code of their open source projects along with license
+information below. We acknowledge and are grateful to these developers for their contributions to open source.
 
 * [Mathias' dotfiles](https://github.com/mathiasbynens/dotfiles) by Mathias Bynens (MIT)
 * [holman does dotfiles](https://github.com/holman/dotfiles) by Zach Holman (MIT)

--- a/config/Terminal/README.md
+++ b/config/Terminal/README.md
@@ -1,1 +1,2 @@
-A collection of color schemes for default macOS Terminal.app can be found here: https://github.com/lysyi3m/macos-terminal-themes
+A collection of color schemes for default macOS Terminal.app can be found
+here: https://github.com/lysyi3m/macos-terminal-themes

--- a/dotfiles/.editorconfig
+++ b/dotfiles/.editorconfig
@@ -10,20 +10,18 @@ insert_final_newline = true
 max_line_length = 120
 trim_trailing_whitespace = true
 
-[{.bash*,*.sh}]
+[{.bash*, *.sh}]
 indent_size = 2
 max_line_length = 80
 
-[*.{css,ts,json,js,tsx,jsx}]
+[*.{css, ts, json, js, tsx, jsx}]
 indent_size = 2
-indent_style = space
 max_line_length = 80
 
 [Dockerfile]
 indent_size = 2
-indent_style = space
 
-[{*.gradle,*.groovy,*Jenkinsfile*}]
+[{*.gradle, *.groovy, *Jenkinsfile*}]
 indent_size = 4
 
 [*.html]
@@ -32,18 +30,13 @@ indent_size = 2
 [*.java]
 indent_size = 2
 max_line_length = 100
-continuation_indent_size = 4
-
-[*.j2]
-end_of_line = lf
+ij_continuation_indent_size = 4
 
 [*.md]
 indent_size = 2
-indent_style = space
 trim_trailing_whitespace = false
 
-[*.{ps1,psm1}]
-charset = utf-8-bom
+[*.{ps1, psm1}]
 indent_size = 4
 
 [*.py]
@@ -54,7 +47,6 @@ max_line_length = 80
 indent_size = 4
 indent_style = tab
 
-[*.{yml,yaml}]
+[*.{yml, yaml}]
 indent_size = 2
-indent_style = space
 max_line_length = 100


### PR DESCRIPTION
* Remove options that duplicates parent [*] settings
* It is not recommended to use 'utf-8-bom', use 'uft-8' instead
* `continuation_indent_size` is an unknown key. Starting from 2019.2 all non-standard properties have got `ij_` prefix.
* Reformat Code