### PR TITLE
Remove google-photos-backup-and-sync

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -45,7 +45,6 @@ if OS.mac?
   cask "evernote"
   cask "flux"
   cask "google-chrome"
-  cask "google-photos-backup-and-sync"
   cask "gpg-suite"
   cask "intellij-idea-ce"
   cask "jiggler"


### PR DESCRIPTION
From October 1st, Backup and Sync will stop working, so you'll need to make the transition to keep backing up your files with Drive.