### PR TITLE
Remove deprecated intellij-idea-ce cask

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -58,8 +58,7 @@ cask "font-fira-code-nerd-font"
 cask "flux-app"
 cask "garmin-express"
 cask "google-chrome"
-cask "intellij-idea" if is_apple_silicon
-cask "intellij-idea-ce" if not is_apple_silicon
+cask "intellij-idea"
 cask "jiggler"
 cask "logi-options+"
 cask "menumeters"


### PR DESCRIPTION
IntelliJ IDEA is now a unified product.

Starting from release (2025.3), there is one IntelliJ IDEA, replacing the separate IntelliJ IDEA Community Edition and IntelliJ IDEA Ultimate to keep things simple and convenient.