### PR TITLE
fix(shellcheck): update aliases to use escaped variables

### DIFF
--- a/dotfiles/.aliases
+++ b/dotfiles/.aliases
@@ -24,7 +24,7 @@ alias pubkey="pbcopy < ~/.ssh/id_rsa.pub | echo '-- Public key copied to pastebo
 alias ws="cd ~/Workspace"
 
 # Detect which `ls` flavor is in use
-if ls --color >/dev/null 2>&1; then # GNU `ls`
+if ls --color > /dev/null 2>&1; then # GNU `ls`
   colorflag="--color"
   export LS_COLORS='no=00:fi=00:di=01;31:ln=01;36:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arj=01;31:*.taz=01;31:*.lzh=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.gz=01;31:*.bz2=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.jpg=01;35:*.jpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.avi=01;35:*.fli=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.ogg=01;35:*.mp3=01;35:*.wav=01;35:'
 else # macOS `ls`
@@ -115,35 +115,35 @@ alias path='echo -e ${PATH//:/\\n}'
 alias findf="find . -type f -iname "
 alias findd="find . -type d -iname "
 function findinfiles() {
-    # Find text in files (and replace text if needed) in current and subdirectories
+  # Find text in files (and replace text if needed) in current and subdirectories
 
-    # Expecting only 1 or 2 arguments to be passed ...
-    if [[ $# -eq 1 || $# -eq 2 ]]; then
-      # Count the number of matches found in files
-      filecount="$(grep -lri --exclude-dir={.git,.idea} -e "$1" . | wc -l)"
-      echo -e "\n$filecount matches found\n"
-      if [ "$filecount" -eq 0 ]; then
-        return
-      else
-        # If only 1 argument is passed, only execute a find
-        if [ $# == 1 ]; then
-          grep -lri --exclude-dir={.git,.idea} -e "$1" .
-        # If 2 arguments are passed, execute a find and replace
-        elif [ $# == 2 ]; then
-          grep -lri --exclude-dir={.git,.idea} -e "$1" .
-          echo -e "\nReplacing \"$1\" with \"$2\" in matches found ..."
-          grep -lri --exclude-dir={.git,.idea} -e "$1" . | xargs sh -c "sed -i '' -e \"s/\$1/\$2/g\" \"\$@\"" _ && echo "Done!"
-        fi
-      fi
-    # Unexpected, or no arguments provided, show usage ...
+  # Expecting only 1 or 2 arguments to be passed ...
+  if [[ $# -eq 1 || $# -eq 2 ]]; then
+    # Count the number of matches found in files
+    filecount="$(grep -lri --exclude-dir={.git,.idea} -e "$1" . | wc -l)"
+    echo -e "\n$filecount matches found\n"
+    if [ "$filecount" -eq 0 ]; then
+      return
     else
-      CMD="findinfiles"
-      echo ""
-      echo "Usage:   $CMD <\"search_pattern\">"
-      echo "Example: $CMD \"refs/tags/v0.24.1\""
-      echo ""
-      echo "Usage:   $CMD <\"regex_search_pattern\"> <\"replacement_string\">"
-      echo "Example: $CMD \"refs\/tags\/v0.24.1\" \"refs\/tags\/v0.24.3\""
+      # If only 1 argument is passed, only execute a find
+      if [ $# == 1 ]; then
+        grep -lri --exclude-dir={.git,.idea} -e "$1" .
+      # If 2 arguments are passed, execute a find and replace
+      elif [ $# == 2 ]; then
+        grep -lri --exclude-dir={.git,.idea} -e "$1" .
+        echo -e "\nReplacing \"$1\" with \"$2\" in matches found ..."
+        grep -lri --exclude-dir={.git,.idea} -e "$1" . | xargs sh -c "sed -i '' -e \"s/\$1/\$2/g\" \"\$@\"" _ && echo "Done!"
+      fi
+    fi
+  # Unexpected, or no arguments provided, show usage ...
+  else
+    CMD="findinfiles"
+    echo ""
+    echo "Usage:   $CMD <\"search_pattern\">"
+    echo "Example: $CMD \"refs/tags/v0.24.1\""
+    echo ""
+    echo "Usage:   $CMD <\"regex_search_pattern\"> <\"replacement_string\">"
+    echo "Example: $CMD \"refs\/tags\/v0.24.1\" \"refs\/tags\/v0.24.3\""
   fi
 }
 

--- a/dotfiles/.aliases
+++ b/dotfiles/.aliases
@@ -33,19 +33,19 @@ else # macOS `ls`
 fi
 
 # List all files colorized in long format
-alias l="ls -lFh ${colorflag}"
+alias l="ls -lFh \${colorflag}"
 
 # List all files colorized in long format, excluding . and ..
-alias la="ls -lAFh ${colorflag}"
+alias la="ls -lAFh \${colorflag}"
 
 # List only directories
-alias ld="ls -lFh ${colorflag} | grep --color=never '^d'"
+alias ld="ls -lFh \${colorflag} | grep --color=never '^d'"
 
 # List all files in reverse lexicographical order
-alias lr="ls -lAFtrh ${colorflag}"
+alias lr="ls -lAFtrh \${colorflag}"
 
 # Always use color output for `ls`
-alias ls="command ls ${colorflag}"
+alias ls="command ls \${colorflag}"
 
 # Always enable colored `grep` output
 # Note: `GREP_OPTIONS="--color=auto"` is deprecated, hence the alias usage.
@@ -106,7 +106,7 @@ alias chromekill="ps ux | grep '[C]hrome Helper --type=renderer' | grep -v exten
 alias zzz="open -a ScreenSaverEngine"
 
 # Reload the shell (i.e. invoke as a login shell)
-alias reload="exec ${SHELL} -l"
+alias reload="exec \${SHELL} -l"
 
 # Print each PATH entry on a separate line
 alias path='echo -e ${PATH//:/\\n}'
@@ -132,7 +132,7 @@ function findinfiles() {
         elif [ $# == 2 ]; then
           grep -lri --exclude-dir={.git,.idea} -e "$1" .
           echo -e "\nReplacing \"$1\" with \"$2\" in matches found ..."
-          grep -lri --exclude-dir={.git,.idea} -e "$1" . | xargs sed -i '' -e "s/$1/$2/g" && echo "Done!"
+          grep -lri --exclude-dir={.git,.idea} -e "$1" . | xargs sh -c "sed -i '' -e \"s/\$1/\$2/g\" \"\$@\"" _ && echo "Done!"
         fi
       fi
     # Unexpected, or no arguments provided, show usage ...
@@ -172,14 +172,14 @@ alias gitauthor='echo GIT_AUTHOR_NAME: $GIT_AUTHOR_NAME \| GIT_AUTHOR_EMAIL: $GI
 function grbi() {
   if [ "$1" == "--help" ]; then
     echo "git rebase interactive options: [null defaults to HEAD~2] | <number of commits> | root " && return
-  elif [ -z $1 ]; then
+  elif [ -z "$1" ]; then
     val="HEAD~2"
   elif [ "$1" == "root" ]; then
     val="--root"
   else
     val="HEAD~$1"
   fi
-  git rebase -i $val
+  git rebase -i "$val"
 }
 
 ## Git branch rename
@@ -261,30 +261,52 @@ alias gt='git tag -l'
 alias dkri='docker images'
 alias dkrrmi='docker rmi'
 alias dkrbu='docker build'
-alias dkrrmi-all='docker rmi $* $(docker images -a -q)'
-alias dkrrmi-dang='docker rmi $* $(docker images -q -f "dangling=true") --force'
+function dkrrmi-all() {
+  docker rmi "$@" "$(docker images -a -q)"
+}
+function dkrrmi-dang() {
+  docker rmi "$@" "$(docker images -q -f "dangling=true")" --force
+}
 
 ## Docker Containers
 alias dkrc='docker ps'
-alias dkrcl='docker ps -l $*'
+function dkrcl() {
+  docker ps -l "$@"
+}
 alias dkrrm='docker rm'
 alias dkrexec='docker exec'
 alias dkrlogs='docker logs'
-alias dkrip='docker inspect --format "{{ .NetworkSettings.IPAddress }}" $*'
-alias dkrstop-all='docker stop $* $(docker ps -q -f "status=running")'
-alias dkrrm-stopped='docker rm $* $(docker ps -q -f "status=exited")'
-alias dkrrmv-stopped='docker rm -v $* $(docker ps -q -f "status=exited")'
-alias dkrrm-all='docker rm $* $(docker ps -a -q)'
-alias dkrrmv-all='docker rm -v $* $(docker ps -a -q)'
+function dkrip() {
+  docker inspect --format "{{ .NetworkSettings.IPAddress }}" "$@"
+}
+function dkrstop-all() {
+  docker stop "$@" "$(docker ps -q -f "status=running")"
+}
+function dkrrm-stopped() {
+  docker rm "$@" "$(docker ps -q -f "status=exited")"
+}
+function dkrrmv-stopped() {
+  docker rm -v "$@" "$(docker ps -q -f "status=exited")"
+}
+function dkrrm-all() {
+  docker rm "$@" "$(docker ps -a -q)"
+}
+function dkrrmv-all() {
+  docker rm -v "$@" "$(docker ps -a -q)"
+}
 
 ## Docker Volumes
-alias dkrvls='docker volume ls $*'
+function dkrvls() {
+  docker volume ls "$@"
+}
 alias dkrvrm-all='docker volume rm $(docker volume ls -q)'
 alias dkrvrm-dang='docker volume rm $(docker volume ls -q -f "dangling=true")'
 
 # Random stuff
 alias ip-public='dig +short myip.opendns.com @resolver1.opendns.com'
-alias ip-local="ifconfig | grep 'inet ' | grep -v 127.0.0.1 | awk '{print \$2}'"
+function ip-local() {
+  ifconfig | grep 'inet ' | grep -v 127.0.0.1 | awk '{print $2}'
+}
 alias weather='clear; curl http://wttr.in/'
 
 # Even more random stuff

--- a/dotfiles/.exports
+++ b/dotfiles/.exports
@@ -23,6 +23,9 @@ export HISTCONTROL='ignoreboth'
 export LANG='en_GB.UTF-8'
 export LC_ALL='en_US.UTF-8'
 
+# Color definitions for terminal capabilities
+yellow='\033[1;33m'
+
 # Highlight section titles in manual pages.
 export LESS_TERMCAP_md="${yellow}"
 


### PR DESCRIPTION
* Correctly escape variables in alias definitions to prevent unintended expansions.
* Convert some aliases to functions for improved flexibility and argument handling.