### PR TITLE
chore(ci): remove Zizmor, re-add TruffleHog and add CSpell maintenance

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -18,7 +18,7 @@
     "Creset",
     "Dont",
     "Dxfxhxhxhxhxcxcx",
-    "Expos\u00e9",
+    "Exposé",
     "Ftrh",
     "HISTCONTROL",
     "HISTFILESIZE",
@@ -40,7 +40,6 @@
     "Rectangl",
     "SHFMT",
     "TERMCAP",
-    "TRUFFLEHOG",
     "Trackpad",
     "appdir",
     "ashokm",
@@ -61,7 +60,6 @@
     "classpath",
     "clmv",
     "colorflag",
-    "corepack",
     "committerdate",
     "connrefused",
     "csshx",
@@ -164,7 +162,6 @@
     "incsearch",
     "inet",
     "intellij",
-    "intune",
     "jdkversions",
     "jiggler",
     "jscoverage",
@@ -277,6 +274,7 @@
     "windowserver",
     "wscript",
     "wvous",
+    "zizmor",
     "zstd"
   ]
 }

--- a/.github/workflows/cspell-stale-words.yml
+++ b/.github/workflows/cspell-stale-words.yml
@@ -1,0 +1,100 @@
+---
+name: CSpell Stale Words
+
+######################################################################
+## minute         0-59
+## hour           0-23
+## day of month   1-31
+## month          1-12
+## day of week    0-7
+######################################################################
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 7 * * 1" # 07:00 every Monday
+  workflow_dispatch: # Allows manual runs from the Actions tab
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  ########################################
+  # Check pull requests for stale words.
+  ########################################
+  check:
+    name: Check for stale CSpell words
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Check for stale words
+        run: python3 scripts/cspell_stale_words.py
+
+  ########################################
+  # Remove stale words and open or update
+  # a pull request for review.
+  ########################################
+  autofix:
+    name: Create CSpell cleanup pull request
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Remove stale words
+        run: python3 scripts/cspell_stale_words.py --fix
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          branch: automation/cspell-stale-words
+          delete-branch: true
+          add-paths: .cspell.json
+          commit-message: "chore(cspell): remove stale words"
+          title: "chore(cspell): remove stale words"
+          body: |
+            Remove stale entries from the CSpell word list.
+
+            These words are no longer used in Git-tracked repository files.
+
+            Please review the removed words before merging.
+          labels: bot

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -40,12 +40,14 @@ jobs:
   megalinter:
     name: MegaLinter
     runs-on: ubuntu-latest
+
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push, comment issues & post new PR
       # Remove the ones you do not need
       contents: write
       issues: write
       pull-requests: write
+
     steps:
       # Git Checkout
       - name: Checkout Code
@@ -68,7 +70,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # ADD YOUR CUSTOM ENV VARIABLES HERE OR DEFINE THEM IN A FILE .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
           # DISABLE: COPYPASTE,SPELL # Uncomment to disable copy-paste and spell checks
-          DISABLE_LINTERS: REPOSITORY_TRUFFLEHOG
+          # Disable ACTION_ZIZMOR for now: blanket unpinned-uses policy is too noisy for these workflows.
+          DISABLE_LINTERS: ACTION_ZIZMOR
           FILTER_REGEX_EXCLUDE: (.git-completion.bash)
           BASH_SHFMT_ARGUMENTS: --indent 2 --space-redirects
 
@@ -85,25 +88,57 @@ jobs:
       # Create pull request if applicable (for now works only on PR from same repository, not from forks)
       - name: Create Pull Request with applied fixes
         id: cpr
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
+        if: >-
+          steps.ml.outputs.has_updated_sources == 1 &&
+          (env.APPLY_FIXES_EVENT == 'all' ||
+          env.APPLY_FIXES_EVENT == github.event_name) &&
+          env.APPLY_FIXES_MODE == 'pull_request' &&
+          (github.event_name == 'push' ||
+          github.event.pull_request.head.repo.full_name == github.repository) &&
+          !contains(github.event.head_commit.message, 'skip fix')
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           commit-message: "[MegaLinter] Apply linters automatic fixes"
           title: "[MegaLinter] Apply linters automatic fixes"
           labels: bot
+
       - name: Create PR output
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
+        if: >-
+          steps.ml.outputs.has_updated_sources == 1 &&
+          (env.APPLY_FIXES_EVENT == 'all' ||
+          env.APPLY_FIXES_EVENT == github.event_name) &&
+          env.APPLY_FIXES_MODE == 'pull_request' &&
+          (github.event_name == 'push' ||
+          github.event.pull_request.head.repo.full_name == github.repository) &&
+          !contains(github.event.head_commit.message, 'skip fix')
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
 
       # Push new commit if applicable (for now works only on PR from same repository, not from forks)
       - name: Prepare commit
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'commit' && github.ref != 'refs/heads/main' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
-        run: sudo chown -Rc $UID .git/
+        if: >-
+          steps.ml.outputs.has_updated_sources == 1 &&
+          (env.APPLY_FIXES_EVENT == 'all' ||
+          env.APPLY_FIXES_EVENT == github.event_name) &&
+          env.APPLY_FIXES_MODE == 'commit' &&
+          github.ref != 'refs/heads/main' &&
+          (github.event_name == 'push' ||
+          github.event.pull_request.head.repo.full_name == github.repository) &&
+          !contains(github.event.head_commit.message, 'skip fix')
+        run: sudo chown -Rc "$UID" .git/
+
       - name: Commit and push applied linter fixes
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'commit' && github.ref != 'refs/heads/main' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
+        if: >-
+          steps.ml.outputs.has_updated_sources == 1 &&
+          (env.APPLY_FIXES_EVENT == 'all' ||
+          env.APPLY_FIXES_EVENT == github.event_name) &&
+          env.APPLY_FIXES_MODE == 'commit' &&
+          github.ref != 'refs/heads/main' &&
+          (github.event_name == 'push' ||
+          github.event.pull_request.head.repo.full_name == github.repository) &&
+          !contains(github.event.head_commit.message, 'skip fix')
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           branch: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref }}

--- a/scripts/cspell_stale_words.py
+++ b/scripts/cspell_stale_words.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Find or remove unused words from .cspell.json."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import shutil
+import subprocess  # nosec B404 - needed for a fixed local git command
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CSPELL = ROOT / ".cspell.json"
+GIT_EXE = shutil.which("git")
+
+
+def tracked_files() -> list[pathlib.Path]:
+    """Return regular, non-symlink Git-tracked files."""
+    if not GIT_EXE:
+        print("ERROR: git executable not found in PATH.", file=sys.stderr)
+        raise SystemExit(2)
+
+    result = subprocess.run(  # nosec B603 - args are static and shell is not used
+        [GIT_EXE, "-C", str(ROOT), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    )
+
+    return [
+        path
+        for name in result.stdout.decode(
+            "utf-8",
+            errors="replace",
+        ).split("\0")
+        if name
+        and (path := ROOT / name).is_file()
+        and not path.is_symlink()
+        and path != CSPELL
+    ]
+
+
+def build_corpus() -> str:
+    """Read tracked UTF-8 text files into a searchable corpus."""
+    text: list[str] = []
+
+    for path in tracked_files():
+        try:
+            text.append(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            continue
+
+    return "\n".join(text)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Remove stale words from .cspell.json",
+    )
+    args = parser.parse_args()
+
+    data = json.loads(CSPELL.read_text(encoding="utf-8"))
+    words = data.get("words", [])
+    corpus = build_corpus()
+
+    stale = [
+        word
+        for word in words
+        if re.search(re.escape(word), corpus, re.IGNORECASE) is None
+    ]
+
+    if not stale:
+        print("No stale CSpell words found.")
+        return 0
+
+    print(f"Found {len(stale)} stale CSpell word(s):")
+
+    for word in stale:
+        print(f"  - {word}")
+
+    if not args.fix:
+        return 1
+
+    stale_words = {word.casefold() for word in stale}
+    data["words"] = [word for word in words if word.casefold() not in stale_words]
+
+    CSPELL.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    print(f"Removed {len(stale)} stale CSpell word(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
* Disable ACTION_ZIZMOR in Megalinter run to avoid noisy unpinned-uses findings.
* Re-enable REPOSITORY_TRUFFLEHOG in MegaLinter so secret scanning runs again alongside the other linters.
* Update MegaLinter comments to clarify permissions, auto-fix behavior, and linter settings.
* Add CSpell stale-word checker with check and fix modes.